### PR TITLE
fix bug: colon in directory

### DIFF
--- a/main_iql.py
+++ b/main_iql.py
@@ -94,7 +94,7 @@ if __name__ == "__main__":
 
     # make directory
     ts = time.gmtime()
-    ts = time.strftime("%m-%d-%H:%M", ts)
+    ts = time.strftime("%m-%d-%H-%M", ts)
     exp_name = str(args.env) + '-' + ts + '-bs' + str(args.batch_size) + '-s' + str(args.seed)
     if args.policy == 'IQL':
         exp_name += '-t' + str(args.temperature) + '-e' + str(args.expectile)


### PR DESCRIPTION
fix a bug that will prevent the code from running correctly
there is a ":" in this directory string and cannot be resloved, just simply change this typo to "-"